### PR TITLE
feat: extend confidence model for multi-timeframe analysis

### DIFF
--- a/barchart_swing_bot/confidence.py
+++ b/barchart_swing_bot/confidence.py
@@ -1,28 +1,97 @@
-"""Simple confidence model used for unit tests.
+"""Utility functions for evaluating trade confidence.
 
-The real system would employ a sophisticated ML pipeline. Here we use a
-transparent deterministic function to keep tests lightweight while mimicking the
-behaviour of the production model.
+The production system would normally rely on an ML model fed with a large
+feature set.  For the purposes of the test suite we keep the implementation
+transparent and deterministic while still modelling some of the behaviour one
+would expect from a richer pipeline.  The module now supports additional
+technical indicators, multiple timeframes and a small back‑testing helper to
+evaluate a moving‑average strategy against historical prices.
 """
 
 from __future__ import annotations
 
-from typing import Mapping
+from typing import Mapping, Sequence, Tuple
+
+
+# Weights for individual indicators.  Values are expressed as percentages and
+# sum to 100 so the returned confidence is naturally in the ``0..100`` range.
+WEIGHTS: Mapping[str, float] = {
+    "wtd_alpha": 10,
+    "momentum_daily": 15,
+    "momentum_weekly": 15,
+    "inst_score": 20,
+    "rsi": 10,
+    "stochastic": 10,
+    "macd": 10,
+    "ma_signal": 10,
+}
 
 
 def compute_confidence(features: Mapping[str, float]) -> float:
-    """Return a confidence percentage.
+    """Return a confidence percentage derived from weighted indicators.
 
-    The function is intentionally simple: weights of a few features are summed
-    and clipped to [0, 100].
+    ``features`` is expected to contain values in the ``0..1`` range for each
+    key in :data:`WEIGHTS`.  Missing features contribute ``0`` to the final
+    score.  The result is clipped to ``0..100`` for safety.
     """
 
     score = 0.0
-    score += float(features.get("wtd_alpha", 0)) * 10
-    score += float(features.get("momentum", 0)) * 20
-    score += float(features.get("inst_score", 0)) * 30
+    for key, weight in WEIGHTS.items():
+        score += float(features.get(key, 0)) * weight
     return max(0.0, min(100.0, score))
 
 
 def is_actionable(features: Mapping[str, float]) -> bool:
+    """Return ``True`` when the computed confidence meets the 80 % threshold."""
+
     return compute_confidence(features) >= 80
+
+
+def determine_best_timeframe(
+    daily: Mapping[str, float], weekly: Mapping[str, float]
+) -> Tuple[str, float, bool]:
+    """Select the timeframe with the highest confidence.
+
+    Returns a tuple of ``(timeframe, confidence, passes)`` where ``passes``
+    indicates whether the winning timeframe meets the 80 % actionable
+    threshold.
+    """
+
+    daily_conf = compute_confidence(daily)
+    weekly_conf = compute_confidence(weekly)
+    if daily_conf >= weekly_conf:
+        return "daily", daily_conf, daily_conf >= 80
+    return "weekly", weekly_conf, weekly_conf >= 80
+
+
+def backtest_moving_average(
+    prices: Sequence[float], short: int = 20, long: int = 50
+) -> float:
+    """Back‑test a simple moving‑average crossover strategy.
+
+    The function iterates over ``prices`` and records the cumulative return of a
+    long‑only strategy that buys when the short moving average crosses above the
+    long moving average and sells on the inverse crossover.  The function
+    returns the total return percentage (e.g. ``0.5`` for ``50 %``).
+    """
+
+    if long <= 0 or short <= 0 or long <= short:
+        raise ValueError("long window must be greater than short window")
+    if len(prices) < long + 1:
+        return 0.0
+    total_return = 0.0
+    position = 0  # 0 = flat, 1 = long
+    entry_price = 0.0
+    for idx in range(long, len(prices)):
+        short_ma = sum(prices[idx - short : idx]) / short
+        long_ma = sum(prices[idx - long : idx]) / long
+        price = prices[idx]
+        if short_ma > long_ma and position == 0:
+            position = 1
+            entry_price = price
+        elif short_ma < long_ma and position == 1:
+            total_return += price / entry_price - 1
+            position = 0
+    if position == 1:  # close any open position at the last price
+        total_return += prices[-1] / entry_price - 1
+    return total_return

--- a/tests/test_confidence.py
+++ b/tests/test_confidence.py
@@ -1,13 +1,69 @@
-from barchart_swing_bot.confidence import compute_confidence, is_actionable
+from barchart_swing_bot.confidence import (
+    backtest_moving_average,
+    compute_confidence,
+    determine_best_timeframe,
+    is_actionable,
+)
 
 
 def test_confidence_actionable():
-    features = {"wtd_alpha": 3, "momentum": 1, "inst_score": 1}
+    features = {
+        "wtd_alpha": 1,
+        "momentum_daily": 1,
+        "momentum_weekly": 1,
+        "inst_score": 1,
+        "rsi": 1,
+        "stochastic": 0,
+        "macd": 1,
+        "ma_signal": 0,
+    }
     assert compute_confidence(features) == 80
     assert is_actionable(features)
 
 
 def test_confidence_not_actionable():
-    features = {"wtd_alpha": 1, "momentum": 0, "inst_score": 1}
-    assert compute_confidence(features) == 40
+    features = {
+        "wtd_alpha": 1,
+        "momentum_daily": 0,
+        "momentum_weekly": 1,
+        "inst_score": 1,
+        "rsi": 0,
+        "stochastic": 0,
+        "macd": 1,
+        "ma_signal": 1,
+    }
+    assert compute_confidence(features) == 65
     assert not is_actionable(features)
+
+
+def test_determine_best_timeframe():
+    daily = {
+        "wtd_alpha": 1,
+        "momentum_daily": 1,
+        "momentum_weekly": 0,
+        "inst_score": 1,
+        "rsi": 1,
+        "stochastic": 1,
+        "macd": 1,
+        "ma_signal": 1,
+    }
+    weekly = {
+        "wtd_alpha": 1,
+        "momentum_daily": 0,
+        "momentum_weekly": 1,
+        "inst_score": 1,
+        "rsi": 1,
+        "stochastic": 0,
+        "macd": 1,
+        "ma_signal": 0,
+    }
+    tf, conf, passes = determine_best_timeframe(daily, weekly)
+    assert tf == "daily"
+    assert conf == compute_confidence(daily)
+    assert passes
+
+
+def test_backtest_moving_average():
+    prices = [1, 2, 3, 4, 5, 6]
+    result = backtest_moving_average(prices, short=2, long=3)
+    assert result == 0.5


### PR DESCRIPTION
## Summary
- expand confidence model with weighted technical indicators
- add helpers to choose best timeframe and backtest moving average strategies
- cover new logic with tests

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a417f321e88331be66a5b8125f1a17